### PR TITLE
Bump Typographic and Axis versions

### DIFF
--- a/.npm/plugin/compileStylus/npm-shrinkwrap.json
+++ b/.npm/plugin/compileStylus/npm-shrinkwrap.json
@@ -43,7 +43,7 @@
       }
     },
     "axis": {
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     "jeet": {
       "version": "6.1.2"
@@ -155,7 +155,7 @@
       }
     },
     "typographic": {
-      "version": "1.1.0"
+      "version": "2.9.1"
     }
   }
 }

--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+## v.NEXT
+
+* Bump Typographic version (from 1.1.0 to 2.9.1)
+* Bump Axis version (from 0.3.0 to 0.3.1)
+
 ## v1.1.0
 
 * Add Axis, Typographic, and Autoprefixer

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ its path by `/`.
 
 Expressive, dynamic, robust CSS. Curly braces and semicolons: optional.
 
-### [Nib](http://visionmedia.github.io/nib/) 1.0.4
+### [Nib](http://tj.github.io/nib/) 1.1.0
 
 Nib is a popular Stylus package that adds many helpful, basic, utility mixins.
 
@@ -47,13 +47,13 @@ It's important to remember to include it in your styles, like so:
 
 Simple media queries for Stylus. Must be imported before use.
 
-### [Typographic](https://github.com/corysimmons/typographic) 1.1.0
+### [Typographic](https://github.com/corysimmons/typographic) 2.9.1
 
 Quick and dirty responsive typography for the rest of us. Offers great selection
 of common font stacks, and several ways to apply them to your document. Must be
 imported before use.
 
-### [Axis](http://axis.netlify.com/) 0.3.0
+### [Axis](http://axis.netlify.com/) 0.3.1
 
 A higher-level Stylus mixin library with lots of extra functionality. Be sure
 not to miss the normalize() mixin. Axis uses and imports Nib, so Nib has been

--- a/package.js
+++ b/package.js
@@ -16,8 +16,8 @@ Package._transitional_registerBuildPlugin({
     nib: "1.1.0",
     jeet: "6.1.2",
     rupture: "0.6.1",
-    axis: "0.3.0",
-    typographic: "1.1.0",
+    axis: "0.3.1",
+    typographic: "2.9.1",
     "autoprefixer-stylus": "0.5.0"
   }
 });

--- a/tests/typographic_.styl
+++ b/tests/typographic_.styl
@@ -1,4 +1,5 @@
 @import "typographic"
 
-t-presets()
-t-headers(garamond)
+$header-font = $garamond
+
+typographic()


### PR DESCRIPTION
Also, update Typographic test, README, and History.

I didn't bump the version because I think that merited some discussion. Typographic has changed significantly since we first included it a month ago. I don't know if many people have started using the new feature, but in updating the test, I realized the interface has changed a great deal, and could be a breaking change for some people. It would be more 'semver' to bump to `2.0.0` in light of that, but then again, people might not know to upgrade, particularly because Meteor doesn't share the same tools as npm users have (such as David) to detect that they have out-of-date packages. It's a tough decision.

Fixes #4 .
